### PR TITLE
Makes BackupKeyspaceSchema return an error on failure

### DIFF
--- a/pkg/cain/cqlsh.go
+++ b/pkg/cain/cqlsh.go
@@ -29,7 +29,7 @@ func BackupKeyspaceSchema(iK8sClient, iDstClient interface{}, namespace, pod, co
 
 	reader := bytes.NewReader(schema)
 	if err := skbn.Upload(iDstClient, dstPrefix, schemaToPath, "", reader); err != nil {
-		return "", nil
+		return "", err
 	}
 
 	return dstBasePath, nil


### PR DESCRIPTION
Ran into an issue where a coworker had introduced some s3 bucket policies that strictly enforced encryption headers. They weren't required because the backup bucket had default server-side encryption enabled and the aws sdk took care of all of that on the backend. However, since this return block did not include the error, the app kept on rolling into the copy step and we were getting 404 errors in the logs because the entire path prefix had been wiped out because of this return. Took me all day to narrow down so thought I'd PR this to save someone else the headache if they ever run into this issue.